### PR TITLE
rf-server refactor; rf-slave stability; misc bugfixes & cleanups

### DIFF
--- a/rf-controller/src/nox/netapps/routeflowc/routeflowc.cc
+++ b/rf-controller/src/nox/netapps/routeflowc/routeflowc.cc
@@ -188,7 +188,7 @@ void RouteFlowC::process_message(base_msg * msg) {
 					ofm = (ofp_flow_mod*) raw_of.get();
 					::memcpy(&ofm->header, &flow_msg.flow_mod, size);
 
-					VLOG_INFO(lg, "Flow Command to datapath  with id %llx", flow_msg.datapath_id);
+					VLOG_INFO(lg, "Flow Command to datapath  with id 0x%llx", flow_msg.datapath_id);
 					if (send_openflow_command(datapathid::from_host(
 							flow_msg.datapath_id), &ofm->header, true))
 						VLOG_INFO(lg, "Couldn't send flow");
@@ -218,11 +218,11 @@ void RouteFlowC::process_message(base_msg * msg) {
 			if (i  != pack_buffer.end()){
 				Array_buffer buff(i->second.size);
 				memcpy(buff.data(),  i->second.packet, i->second.size);
-				VLOG_DBG(lg, "datapath with id %llx, port number %d", pack_msg.datapath_id, pack_msg.port_out);
+				VLOG_DBG(lg, "datapath with id 0x%llx, port number %d", pack_msg.datapath_id, pack_msg.port_out);
 				if (send_openflow_packet(datapathid::from_host(pack_msg.datapath_id),
 					(Buffer &) buff, pack_msg.port_out, OFPP_NONE, true) )
-					VLOG_INFO(lg, "Failed to send packet to datapath with id %llx, port number %d", pack_msg.datapath_id, pack_msg.port_out);
-				else VLOG_INFO(lg, "Sending packet to datapath with id %llx, port number %d", pack_msg.datapath_id, pack_msg.port_out);
+					VLOG_INFO(lg, "Failed to send packet to datapath with id 0x%llx, port number %d", pack_msg.datapath_id, pack_msg.port_out);
+				else VLOG_INFO(lg, "Sending packet to datapath with id 0x%llx, port number %d", pack_msg.datapath_id, pack_msg.port_out);
 				pack_buffer.erase(i);
 			}
 
@@ -426,7 +426,7 @@ Disposition RouteFlowC::handle_desc_in(const Event& e) {
 		/*If the server isn't connected queue the event message */
 		events.push(base_message);
 
-	VLOG_INFO(lg, "A new datapath has been registered: id=%llx",
+	VLOG_INFO(lg, "A new datapath has been registered: id=0x%llx",
 			ds.datapath_id.as_host());
 
 	return CONTINUE;
@@ -449,7 +449,7 @@ Disposition RouteFlowC::handle_datapath_leave(const Event& e) {
 	msg_event.datapath_id = dl.datapath_id.as_host();
 	base_message.pay_size = sizeof(msg_event);
 	::memcpy(&base_message.payload, &msg_event, sizeof(msg_event));
-	VLOG_INFO(lg, "Datapath %llx has leaved", dl.datapath_id.as_host() );
+	VLOG_INFO(lg, "Datapath 0x%llx has leaved", dl.datapath_id.as_host() );
 	if (server_sock_fd > 0) {
 
 		if (send(server_sock_fd, &base_message, sizeof(base_msg), 0) == -1)
@@ -525,7 +525,7 @@ void RouteFlowC::server() {
 				else
 				{
 					VLOG_INFO(lg, "Received Message from server");
-					
+
 					while(cmd_mutex)
 					{
 						usleep(1000);

--- a/rf-server/ClientConnection.cc
+++ b/rf-server/ClientConnection.cc
@@ -72,10 +72,10 @@ int32_t ClientConnection::run(void * arg) {
 						} else if (rcount == 0) {
 							/* Client disconnected */
 							syslog(LOG_INFO,
-									"The VM %lld has been disconnected",
+									"The VM 0x%llx has been disconnected",
 									iter->getVmId());
 							if (iter->getMode() == RFP_VM_MODE_RUNNING) {
-								syslog(LOG_DEBUG, "VM = %lld, DpId = %lld",
+								syslog(LOG_DEBUG, "VM = 0x%llx, DpId = 0x%llx",
 										iter->getVmId(), iter->getDpId().dpId);
 								pRFSrv->send_flow_msg(iter->getDpId().dpId,
 										RFO_CLEAR_FLOW_TABLE);

--- a/rf-server/main.cc
+++ b/rf-server/main.cc
@@ -133,8 +133,6 @@ int main(int argc, char **argv) {
 	servAddr.sin_addr.s_addr = INADDR_ANY;
 	servAddr.sin_port = htons(tcpport);
 
-	int bindsocketret = 0;
-
 	while (bind(sockFd, (struct sockaddr *) &servAddr, sizeof(servAddr)) < 0) {
 		syslog(LOG_INFO, "Could not bind server socket");
 		sleep(2);
@@ -217,7 +215,7 @@ int main(int argc, char **argv) {
 				if (!rfSrv.m_dpIdleList.empty()) { //If there is an Idle Datapath.
 					Dp2Vm_t vm2dptmp;
 					vm2dptmp.dpId = rfSrv.Vm2DpMap(vmId);
-					syslog(LOG_DEBUG, "Dp = %lld, VM = %lld", vm2dptmp.dpId,
+					syslog(LOG_DEBUG, "Dp = 0x%llx, VM = 0x%llx", vm2dptmp.dpId,
 							vmId);
 					if (vm2dptmp.dpId != 0) { //The VM has a Datapath assigned to it?
 						syslog(LOG_DEBUG, "Has a Datapath assigned.");
@@ -255,7 +253,7 @@ int main(int argc, char **argv) {
 								rfSrv.m_Dp2VmList.push_front(vm2dptmp);
 								syslog(
 										LOG_DEBUG,
-										"Dp = %lld, VM = %lld added to the List",
+										"Dp = 0x%llx, VM = 0x%llx added to the List",
 										vm2dptmp.dpId, vm2dptmp.vmId);
 								found = 1;
 								break;
@@ -288,7 +286,7 @@ int main(int argc, char **argv) {
 					} else {
 						syslog(
 								LOG_INFO,
-								"The Datapath assigned to VM: %lld isn't connected",
+								"The Datapath assigned to VM: 0x%llx isn't connected",
 								newVM.getVmId());
 					}
 				}
@@ -297,7 +295,7 @@ int main(int argc, char **argv) {
 
 
 				rfSrv.m_vmList.push_back(newVM);
-				syslog(LOG_INFO, "A new VM was registered: VmId=%lld", vmId);
+				syslog(LOG_INFO, "A new VM was registered: VmId=0x%llx", vmId);
 
 				rfSrv.unlockvmList();
 

--- a/rf-server/main.cc
+++ b/rf-server/main.cc
@@ -264,7 +264,7 @@ int main(int argc, char **argv) {
 					}
 					if (found) {
 						/* Install RIPv2 default flow. */
-						rfSrv.send_flow_msg(newVM.getDpId().dpId, RFO_RIPv2);
+						rfSrv.send_flow_msg(newVM.getDpId().dpId, RFO_RIPV2);
 						/* Install OSPF default flow. */
 						rfSrv.send_flow_msg(newVM.getDpId().dpId, RFO_OSPF);
 						/* Install ARP default flow. */

--- a/rf-server/main.cc
+++ b/rf-server/main.cc
@@ -242,7 +242,7 @@ int main(int argc, char **argv) {
 						std::list<Datapath_t>::iterator iter;
 						for (iter = rfSrv.m_dpIdleList.begin(); iter
 								!= rfSrv.m_dpIdleList.end(); iter++) {
-							if (rfSrv.Dp2VmMap(iter->dpId == 0)) { //Is there an Idle Datapath without any VM assigned to it?
+							if (rfSrv.Dp2VmMap(iter->dpId) == 0) { //Is there an Idle Datapath without any VM assigned to it?
 								newVM.setMode(RFP_VM_MODE_RUNNING); //Set VM mode to running (local definition)
 								Datapath_t newDP;
 								newDP.dpId = iter->dpId;

--- a/rf-server/main.cc
+++ b/rf-server/main.cc
@@ -263,12 +263,12 @@ int main(int argc, char **argv) {
 						}
 					}
 					if (found) {
-						/* Install RIPv2 default flow. */
+						/* Install flows to recieve essential traffic. */
 						rfSrv.send_flow_msg(newVM.getDpId().dpId, RFO_RIPV2);
-						/* Install OSPF default flow. */
 						rfSrv.send_flow_msg(newVM.getDpId().dpId, RFO_OSPF);
-						/* Install ARP default flow. */
 						rfSrv.send_flow_msg(newVM.getDpId().dpId, RFO_ARP);
+						rfSrv.send_flow_msg(newVM.getDpId().dpId, RFO_BGP);
+						rfSrv.send_flow_msg(newVM.getDpId().dpId, RFO_ICMP);
 
 						/* Configuration message to the slave. */
 						RFVMMsg logmsg;

--- a/rf-server/main.cc
+++ b/rf-server/main.cc
@@ -42,13 +42,33 @@ using std::memset;
 
 RouteFlowServer rfSrv(TCP_PORT, VIRT_N_FORWARD_PLANE);
 
+void usage(const char *prog) {
+	fprintf(stderr, "\nUsage: %s [-m] [-h]\n", prog);
+	fprintf(stderr, "  -m              Do L2 flow matching (default: off)\n");
+	fprintf(stderr, "  -h              Show this usage message\n");
+}
+
 int main(int argc, char **argv) {
 
 	timeval t;
-	int sockFd, connCount;
+	int sockFd, connCount, opt;
 	socklen_t cliLength;
 	struct sockaddr_in servAddr;
 	int8_t ret = SUCCESS;
+
+	while ((opt = getopt(argc, argv, "hm")) != -1) {
+		switch (opt) {
+		case 'h':
+			usage(argv[0]);
+			exit(0);
+			break;
+		case 'm':
+			rfSrv.set_l2_match(true);
+			break;
+		default:
+			break;
+		}
+	}
 
 	openlog("rf-server", LOG_PID, SYSLOGFACILITY);
 

--- a/rf-server/rfserver.cc
+++ b/rf-server/rfserver.cc
@@ -448,7 +448,7 @@ int RouteFlowServer::send_flow_msg(uint64_t dp_id, qfoperation_t operation) {
 	if (operation == RFO_RIPV2) {
 		syslog(LOG_DEBUG, "[RFSERVER] Configuring flow table for RIPv2");
 		ofm_match_dl(ofm, OFPFW_DL_TYPE, 0x0800, 0, 0);
-		ofm_match_nw(ofm, (OFPFW_NW_PROTO & OFPFW_NW_DST_MASK), 0x11, 0, 0, 
+		ofm_match_nw(ofm, (OFPFW_NW_PROTO | OFPFW_NW_DST_MASK), 0x11, 0, 0,
 			inet_addr("224.0.0.9"));
 	} else if (operation == RFO_OSPF) {
 		syslog(LOG_DEBUG, "[RFSERVER] Configuring flow table for OSPF");
@@ -600,7 +600,7 @@ int RouteFlowServer::process_msg(RFMessage * msg) {
 
 				ofm_init(ofm, size);
 
-				ofm_match_dl(ofm, (OFPFW_DL_TYPE & OFPFW_DL_DST), 0x0800, 0, actions.srcMac);
+				ofm_match_dl(ofm, (OFPFW_DL_TYPE | OFPFW_DL_DST), 0x0800, 0, actions.srcMac);
 				ofm_match_nw(ofm, (((uint32_t) 31 + rules.mask) << OFPFW_NW_DST_SHIFT),	0, 0,
 					0, rules.ip);
 
@@ -682,7 +682,7 @@ int RouteFlowServer::process_msg(RFMessage * msg) {
 
 				ofm_init(ofm, size);
 
-				ofm_match_dl(ofm, (OFPFW_DL_TYPE & OFPFW_DL_DST), 0x0800, 0, actions.srcMac);
+				ofm_match_dl(ofm, (OFPFW_DL_TYPE | OFPFW_DL_DST), 0x0800, 0, actions.srcMac);
 				ofm_match_nw(ofm, (((uint32_t) 31 + rules.mask) << OFPFW_NW_DST_SHIFT),
 					0, 0, 0, rules.ip);
 

--- a/rf-server/rfserver.cc
+++ b/rf-server/rfserver.cc
@@ -134,7 +134,7 @@ int32_t RouteFlowServer::packet_in_event(uint64_t dpId, uint32_t inPort,
 
 	syslog(
 			LOG_INFO,
-			"[RFSERVER] A packet has been received from datapath %llx, port %d",
+			"[RFSERVER] A packet has been received from datapath 0x%llx, port %d",
 			dpId, inPort);
 
 	int found = 0;
@@ -165,7 +165,7 @@ int32_t RouteFlowServer::packet_in_event(uint64_t dpId, uint32_t inPort,
 				send_IPC_packetmsg(dpId, pktId, port);
 				syslog(
 						LOG_INFO,
-						"[RFSERVER] A packet has been transmitted to Datapath %llx port=%d)",
+						"[RFSERVER] A packet has been transmitted to Datapath 0x%llx port=%d)",
 						dpId, port);
 				return 0;
 
@@ -194,7 +194,7 @@ int32_t RouteFlowServer::packet_in_event(uint64_t dpId, uint32_t inPort,
 					send_IPC_packetmsg(ovsdp.dpId, pktId, port);
 					syslog(
 							LOG_INFO,
-							"[RFSERVER] A packet has been transmitted to VM %lld (dpid=%llx port=%d)",
+							"[RFSERVER] A packet has been transmitted to VM 0x%llx (dpid=0x%llx port=%d)",
 							iter->getVmId(), iter->getDpId().dpId, port);
 					break;
 				}
@@ -399,7 +399,7 @@ int32_t RouteFlowServer::datapath_join_event(uint64_t dpId, char hw_desc[],
 	send_flow_msg(dpId, RFO_ICMP);
 	send_flow_msg(dpId, RFO_BGP);
 
-	syslog(LOG_INFO, "[RFSERVER] A new datapath has been registered: id=%llx",
+	syslog(LOG_INFO, "[RFSERVER] A new datapath has been registered: id=0x%llx",
 			dpId);
 
 	return 0;
@@ -504,7 +504,7 @@ int32_t RouteFlowServer::datapath_leave_event(uint64_t dpId) {
 	for (iter = m_vmList.begin(); iter != m_vmList.end(); iter++) {
 		if (iter->getDpId().dpId == dpId) {
 			iter->setMode(RFP_VM_MODE_STANDBY);
-			syslog(LOG_DEBUG, "[RFSERVER] Datapath %lld disconnected", dpId);
+			syslog(LOG_DEBUG, "[RFSERVER] Datapath 0x%llx disconnected", dpId);
 			RFVMMsg msg;
 
 			msg.setDstIP("10.4.1.26");
@@ -532,7 +532,7 @@ int32_t RouteFlowServer::datapath_leave_event(uint64_t dpId) {
 			}
 		}
 		syslog(LOG_WARNING,
-				"[RFSERVER] The datapath %lld has left, but it was not "
+				"[RFSERVER] The datapath 0x%llx has left, but it was not "
 					"registered", dpId);
 	}
 
@@ -589,7 +589,7 @@ int RouteFlowServer::process_msg(RFMessage * msg) {
 		std::list<RFVirtualMachine>::iterator iter;
 		for (iter = m_vmList.begin(); iter != m_vmList.end(); iter++) {
 			if (iter->getVmId() == vmId) {
-				syslog(LOG_DEBUG, "[RFSERVER] Virtual Machine Id %lld",
+				syslog(LOG_DEBUG, "[RFSERVER] Virtual Machine Id 0x%llx",
 						iter->getVmId());
 
 				ofp_flow_mod* ofm;
@@ -672,7 +672,7 @@ int RouteFlowServer::process_msg(RFMessage * msg) {
 		std::list<RFVirtualMachine>::iterator iter;
 		for (iter = m_vmList.begin(); iter != m_vmList.end(); iter++) {
 			if (iter->getVmId() == vm_id) {
-				syslog(LOG_DEBUG, "[RFSERVER] Virtual Machine Id %lld",
+				syslog(LOG_DEBUG, "[RFSERVER] Virtual Machine Id 0x%llx",
 						iter->getVmId());
 
 				ofp_flow_mod* ofm;
@@ -770,7 +770,7 @@ int RouteFlowServer::send_IPC_flowmsg(uint64_t dpid, uint8_t msg[], size_t size)
 		if (ret == -1)
 			usleep(1000);
 		else
-			syslog(LOG_INFO, "[RFSERVER] Msg sent successfully to %llx", dpid);
+			syslog(LOG_INFO, "[RFSERVER] Msg sent successfully to 0x%llx", dpid);
 	} while (ret == -1);
 
 	delete(controller_msg);

--- a/rf-server/rfserver.cc
+++ b/rf-server/rfserver.cc
@@ -38,6 +38,7 @@
 const uint8_t LOCKED = 1;
 const uint8_t UNLOCKED = 0;
 int ovs_portson = 0;
+bool match_l2 = false;
 
 using std::map;
 using std::pair;
@@ -54,6 +55,13 @@ RouteFlowServer::RouteFlowServer(uint16_t srvPort, rf_operation_t op) {
 	operation = op;
 
 	this->ListvmLock = UNLOCKED;
+}
+
+/*
+ * Set whether to do Layer 2 matching in flows
+ */
+void RouteFlowServer::set_l2_match(bool match) {
+	match_l2 = match;
 }
 
 /*
@@ -600,7 +608,9 @@ int RouteFlowServer::process_msg(RFMessage * msg) {
 
 				ofm_init(ofm, size);
 
-				ofm_match_dl(ofm, (OFPFW_DL_TYPE | OFPFW_DL_DST), 0x0800, 0, actions.srcMac);
+				ofm_match_dl(ofm, OFPFW_DL_TYPE , 0x0800, 0, 0);
+				if (match_l2)
+					ofm_match_dl(ofm, OFPFW_DL_DST, 0, 0, actions.srcMac);
 				ofm_match_nw(ofm, (((uint32_t) 31 + rules.mask) << OFPFW_NW_DST_SHIFT),	0, 0,
 					0, rules.ip);
 
@@ -682,7 +692,10 @@ int RouteFlowServer::process_msg(RFMessage * msg) {
 
 				ofm_init(ofm, size);
 
-				ofm_match_dl(ofm, (OFPFW_DL_TYPE | OFPFW_DL_DST), 0x0800, 0, actions.srcMac);
+				ofm_match_dl(ofm, OFPFW_DL_TYPE , 0x0800, 0, 0);
+				if (match_l2)
+					ofm_match_dl(ofm, OFPFW_DL_DST, 0, 0, actions.srcMac);
+
 				ofm_match_nw(ofm, (((uint32_t) 31 + rules.mask) << OFPFW_NW_DST_SHIFT),
 					0, 0, 0, rules.ip);
 

--- a/rf-server/rfserver.cc
+++ b/rf-server/rfserver.cc
@@ -436,7 +436,7 @@ int RouteFlowServer::send_flow_msg(uint64_t dp_id, qfoperation_t operation) {
 	ofp_flow_mod* ofm;
 	size_t size = sizeof *ofm;
 
-	if (operation != RFO_CLEAR_TABLE && operation != RFO_DROP_ALL) {
+	if (operation != RFO_CLEAR_FLOW_TABLE && operation != RFO_DROP_ALL) {
 		size = sizeof *ofm + sizeof(ofp_action_output);
 	}
 
@@ -472,7 +472,7 @@ int RouteFlowServer::send_flow_msg(uint64_t dp_id, qfoperation_t operation) {
 		ofm->priority = htons(1);
 	}
 
-	if (operation == RFO_CLEAR_TABLE) {
+	if (operation == RFO_CLEAR_FLOW_TABLE) {
 		syslog(LOG_DEBUG, "[RFSERVER] Clearing flow table");
 		ofm_set_command(ofm, OFPFC_DELETE, 0, 0, 0, OFPP_NONE);
 		ofm->priority = htons(0);

--- a/rf-server/rfserver.hh
+++ b/rf-server/rfserver.hh
@@ -156,6 +156,18 @@ public:
 	int send_IPC_packetmsg(uint64_t dpid, uint64_t MsgId, uint16_t port_out);
 
 	int VmToOvsMapping(uint64_t vmId, uint16_t VmPort, uint16_t OvsPort);
+
+	/* Rules to add OF matches to OF mods */
+	void ofm_init(ofp_flow_mod* ofm, size_t size);
+	void ofm_match_iface(ofp_flow_mod* ofm, uint16_t in);
+	void ofm_match_eth(ofp_flow_mod* ofm, uint32_t match, uint16_t type,
+        const uint8_t src[], const uint8_t dst[]);
+	void ofm_match_vlan(ofp_flow_mod* ofm, uint32_t match, uint16_t id,
+        uint8_t priority);
+	void ofm_match_ip(ofp_flow_mod* ofm, uint32_t match, uint8_t proto,
+        uint8_t tos, uint32_t src, uint32_t dst);
+	void ofm_match_tp(ofp_flow_mod* ofm, uint32_t match,
+        uint16_t src, uint16_t dst);
 };
 
 #endif /* QFSERVER_HH_ */

--- a/rf-server/rfserver.hh
+++ b/rf-server/rfserver.hh
@@ -150,6 +150,8 @@ public:
 
 	int VmToOvsMapping(uint64_t vmId, uint16_t VmPort, uint16_t OvsPort);
 
+	void set_l2_match(bool match);
+
 	/* Functions for adding OF matches to OF flowmods */
 	void ofm_init(ofp_flow_mod* ofm, size_t size);
 	void ofm_match_in(ofp_flow_mod* ofm, uint16_t in);

--- a/rf-server/rfserver.hh
+++ b/rf-server/rfserver.hh
@@ -171,6 +171,9 @@ public:
 
 	void ofm_set_action(ofp_action_header* pAction, uint16_t type, uint16_t len,
 		uint16_t port, uint16_t max_len, const uint8_t addr[]);
+
+	void ofm_set_command(ofp_flow_mod* ofm, uint16_t cmd, uint32_t id,
+		uint16_t idle_to, uint16_t hard_to, uint16_t port);
 };
 
 #endif /* QFSERVER_HH_ */

--- a/rf-server/rfserver.hh
+++ b/rf-server/rfserver.hh
@@ -159,12 +159,12 @@ public:
 
 	/* Functions for adding OF matches to OF flowmods */
 	void ofm_init(ofp_flow_mod* ofm, size_t size);
-	void ofm_match_iface(ofp_flow_mod* ofm, uint16_t in);
-	void ofm_match_eth(ofp_flow_mod* ofm, uint32_t match, uint16_t type,
+	void ofm_match_in(ofp_flow_mod* ofm, uint16_t in);
+	void ofm_match_dl(ofp_flow_mod* ofm, uint32_t match, uint16_t type,
         const uint8_t src[], const uint8_t dst[]);
 	void ofm_match_vlan(ofp_flow_mod* ofm, uint32_t match, uint16_t id,
         uint8_t priority);
-	void ofm_match_ip(ofp_flow_mod* ofm, uint32_t match, uint8_t proto,
+	void ofm_match_nw(ofp_flow_mod* ofm, uint32_t match, uint8_t proto,
         uint8_t tos, uint32_t src, uint32_t dst);
 	void ofm_match_tp(ofp_flow_mod* ofm, uint32_t match,
         uint16_t src, uint16_t dst);

--- a/rf-server/rfserver.hh
+++ b/rf-server/rfserver.hh
@@ -30,15 +30,15 @@ using std::list;
 using std::multimap;
 
 typedef enum rfoperation {
-	RFO_DROP_ALL,		/* Drop all incoming packets. */
-	RFO_CLEAR_TABLE,	/* Clear flow table. */
-	RFO_VM_INFO,		/* Flow to communicate two linked VM's. */
-	RFO_RIPV2,			/* RIPv2 protocol. */
-	RFO_OSPF,			/* OSPF protocol. */
-	RFO_BGP,			/* BGP protocol. */
-	RFO_ARP,			/* ARP protocol. */
-	RFO_ICMP,			/* ICMP protocol. */
-	RFO_ALL				/*Send all traffic to the controller. */
+	RFO_DROP_ALL,			/* Drop all incoming packets. */
+	RFO_CLEAR_FLOW_TABLE,	/* Clear flow table. */
+	RFO_VM_INFO,			/* Flow to communicate two linked VM's. */
+	RFO_RIPV2,				/* RIPv2 protocol. */
+	RFO_OSPF,				/* OSPF protocol. */
+	RFO_BGP,				/* BGP protocol. */
+	RFO_ARP,				/* ARP protocol. */
+	RFO_ICMP,				/* ICMP protocol. */
+	RFO_ALL					/*Send all traffic to the controller. */
 } qfoperation_t;
 
 typedef enum rf_operation{

--- a/rf-server/rfserver.hh
+++ b/rf-server/rfserver.hh
@@ -30,23 +30,16 @@ using std::list;
 using std::multimap;
 
 typedef enum rfoperation {
-	RFO_RIPv2,	/* RIPv2 protocol. */
-	RFO_OSPF,	/* OSPF protocol. */
-	RFO_BGP,	/* BGP protocol. */
-	RFO_ARP,	/* ARP protocol. */
-	RFO_ICMP,   /* ICMP protocol. */
-	RFO_CLEAR_FLOW_TABLE /* Clear flow table. */
+	RFO_DROP_ALL,		/* Drop all incoming packets. */
+	RFO_CLEAR_TABLE,	/* Clear flow table. */
+	RFO_VM_INFO,		/* Flow to communicate two linked VM's. */
+	RFO_RIPV2,			/* RIPv2 protocol. */
+	RFO_OSPF,			/* OSPF protocol. */
+	RFO_BGP,			/* BGP protocol. */
+	RFO_ARP,			/* ARP protocol. */
+	RFO_ICMP,			/* ICMP protocol. */
+	RFO_ALL				/*Send all traffic to the controller. */
 } qfoperation_t;
-
-/* Open vSwitch operations */
-typedef enum ovs_operation {
-	DROP_ALL, /* Drop all incoming packets. */
-	VM_FLOW,  /* Flow to communicate two linked VM's. */
-	VM_INFO,  /* Flow to send the MAP Event packet to the controller. */
-	ARP,	 /* To not drop ARP packets */
-	ICMP, 	 /* To not drop ICMP packets */
-	CONTROLLER /*Send all traffic to the controller */
-} ovs_operation_t;
 
 typedef enum rf_operation{
 
@@ -143,7 +136,7 @@ public:
 	int send_flow_msg(uint64_t dp, qfoperation_t operation);
 
 	void send_ovs_flow(uint64_t dp1, uint64_t dp2, uint8_t port1,
-			uint8_t port2, ovs_operation_t ovs_op);
+			uint8_t port2, ofp_flow_mod_command cmd);
 
 	int process_msg(RFMessage * msg);
 

--- a/rf-server/rfserver.hh
+++ b/rf-server/rfserver.hh
@@ -157,7 +157,7 @@ public:
 
 	int VmToOvsMapping(uint64_t vmId, uint16_t VmPort, uint16_t OvsPort);
 
-	/* Rules to add OF matches to OF mods */
+	/* Functions for adding OF matches to OF flowmods */
 	void ofm_init(ofp_flow_mod* ofm, size_t size);
 	void ofm_match_iface(ofp_flow_mod* ofm, uint16_t in);
 	void ofm_match_eth(ofp_flow_mod* ofm, uint32_t match, uint16_t type,
@@ -168,6 +168,9 @@ public:
         uint8_t tos, uint32_t src, uint32_t dst);
 	void ofm_match_tp(ofp_flow_mod* ofm, uint32_t match,
         uint16_t src, uint16_t dst);
+
+	void ofm_set_action(ofp_action_header* pAction, uint16_t type, uint16_t len,
+		uint16_t port, uint16_t max_len, const uint8_t addr[]);
 };
 
 #endif /* QFSERVER_HH_ */

--- a/rf-slave/rfslave.cc
+++ b/rf-slave/rfslave.cc
@@ -394,7 +394,7 @@ int rf_register(const char* iface, const char* server) {
 	gVmId = get_vmId(iface);
 	gVmIpAddr = get_ipaddr_byname(iface);
 
-	syslog(LOG_INFO, "gVmId=%llx", gVmId);
+	syslog(LOG_INFO, "gVmId=0x%llx", gVmId);
 
 	RFVMMsg msg;
 
@@ -434,7 +434,7 @@ int rf_connect(const char* iface, const char* server, int port) {
 		return -1;
 	}
 
-	syslog(LOG_DEBUG, "Connection msg (%lx bytes)", pMsg->length());
+	syslog(LOG_DEBUG, "Connection msg (%ld bytes)", pMsg->length());
 	if (RFP_CMD_ACCPET != pMsg->getType()) {
 		rfSock.rfClose();
 		syslog(LOG_ERR, "Registration error type:%x", pMsg->getType());
@@ -506,7 +506,7 @@ int main(int argc, char *argv[]) {
 			pMsg = rfSock.rfRecv();
 
 			if (NULL != pMsg) {
-				syslog(LOG_DEBUG, "New msg (%lx bytes)", pMsg->length());
+				syslog(LOG_DEBUG, "New msg (%ld bytes)", pMsg->length());
 				process_msg(pMsg);
 				delete (pMsg);
 			} else {


### PR DESCRIPTION
## General
- VM ids and Datapath ids are now universally formatted as "0x%llx"
## rf-server

I've done some fairly invasive work in rf-server to refactor duplicate code into some handy functions. These take the form of "ofm_foo()", and are currently inside rfserver.cc, but could be spun out into a seperate library for OF-mod creation, if need be. 

I also refactored most code that previously used send_ovs_flow() to send messages to the RFOVS datapath so that it makes use of send_flow_msg() instead. The remaining places where send_ovs_flow() is used are for specifying physical port mappings. This method now takes an ofp_flow_mod_command to specify whether it is adding or deleting a port map. 

Lastly, there is now also commandline argument parsing for rf-server. Perhaps at a later date, a config file would be preferred, but at the moment the only thing that I needed to configure was whether or not L2 matching was done, so I thought config file parsing would be a bit over-the-top.

_Refactored OpenFlow mod creation code:-_
- Wildcards are added by the various ofm_match_foo() functions
- Actions are added by ofm_set_action() calls
- Commands are added by ofm_set_command() calls
- Almost all calls to send_ovs_flow() are replaced with send_flow_msg() calls
- send_ovs_flow() now only handles sending ADD and DELETE OFM commands for physical ports

_General bugfixes/modifications:-_
- Typo in rf-server/main.cc that caused VMs to not associate with an idle DP
- Install flows into DP (when VM joins) to forward ICMP,BGP messages to the controller
- Added commandline argument parsing; To do L2 matching, specify -m
- Add function RouteFlowServer::set_l2_match(bool) for setting whether to match L2 or not
- All RF Operations such as DROP_ALL, CLEAR_FLOW_TABLE, and matching different protocols are now specified as RFO_foo
## rf-slave

One of the bigger problems I previously had with rf-slave is that when any kind of network issue occurred, rf-slave would print a message and exit out. I've changed this so that it will only exit if there are troubles with ioctl() on the sockets. All debug output is now standardised also.

_General bugfixes/modifications:-_
- Don't die when connection to rf-server is lost -- go back to looking for the server again
- Change all output to one standard format, using syslog
