### PR TITLE
Build fixes for Ubuntu 11.10

### DIFF
--- a/rf-controller/config/ax_ssl.m4
+++ b/rf-controller/config/ax_ssl.m4
@@ -4,8 +4,10 @@ AC_CHECK_HEADER([openssl/md5.h],
     AC_ERROR([openssl/md5.h not found. NOX requires OpenSSL])
 )
 AC_CHECK_LIB(ssl, MD5_Init,
-             [SSL_LIBS="-lssl"; AC_SUBST(SSL_LIBS) break],
-             [AC_ERROR([openssl/md5.h not found. NOX requires OpenSSL])])
+             [SSL_LIBS="-lssl"; AC_SUBST(SSL_LIBS) break],[
+             AC_CHECK_LIB(crypto, MD5_Init,
+             [SSL_LIBS="-lssl -lcrypto"; AC_SUBST(SSL_LIBS) break],
+             [AC_ERROR([MD5_Init() is not linkable. NOX requires OpenSSL])])])
 AC_CHECK_PROG(OPENSSL_PROG, openssl,
              [yes],
              [AC_ERROR([openssl program not found. NOX requires OpenSSL])])

--- a/rf-controller/src/nox/netapps/tablog/tablog.hh
+++ b/rf-controller/src/nox/netapps/tablog/tablog.hh
@@ -21,6 +21,9 @@
 #include "component.hh"
 #include "config.h"
 #include "hash_map.hh"
+/** Fix compiling on Ubuntu 11.10 by forcing Boost Filesystem V2
+ */
+#define BOOST_FILESYSTEM_VERSION 2
 #include <boost/filesystem/operations.hpp>
 
 #ifdef LOG4CXX_ENABLED


### PR DESCRIPTION
Hi,
RouteFlow does not compile properly on the latest Ubuntu.
(1) MD5_Init() is in libcrypt instead of libssl
(2) RouteFlow is written with Boost filesystem version 2, the latest Ubuntu uses version 3 by default.

I have only tested these changes on Ubuntu 11.10 and not on other distributions, and I'm not familiar with Autotools so there is a chance that the first change will need rewriting.

Regards,
Dan
