### PR TITLE
Securing RouteFlow

### DIFF
--- a/rflib/defs.h
+++ b/rflib/defs.h
@@ -27,7 +27,8 @@ typedef enum dp_config {
 	DC_VM_INFO,			    /* Flow to communicate two linked VM's */
 	DC_RIPV2,				/* RIPv2 protocol */
 	DC_OSPF,				/* OSPF protocol */
-	DC_BGP,				    /* BGP protocol */
+	DC_BGP_INBOUND,		    /* BGP protocol */
+	DC_BGP_OUTBOUND,		/* BGP protocol */
 	DC_ARP,				    /* ARP protocol */
 	DC_ICMP,				/* ICMP protocol */
 	DC_ALL					/* Send all traffic to the controller */

--- a/rflib/defs.py
+++ b/rflib/defs.py
@@ -23,10 +23,11 @@ DC_CLEAR_FLOW_TABLE = 1 # Clear flow table
 DC_VM_INFO = 2		    # Flow to communicate two linked VMs
 DC_RIPV2 = 3			# RIPv2 protocol
 DC_OSPF = 4 			# OSPF protocol
-DC_BGP = 5			    # BGP protocol
-DC_ARP = 6			    # ARP protocol
-DC_ICMP = 7 			# ICMP protocol
-DC_ALL = 8				# Send all traffic to the controller
+DC_BGP_INBOUND = 5	    # BGP protocol
+DC_BGP_OUTBOUND = 6		# BGP protocol
+DC_ARP = 7			    # ARP protocol
+DC_ICMP = 8 			# ICMP protocol
+DC_ALL = 9				# Send all traffic to the controller
 
 PC_MAP = 0
 PC_RESET = 1

--- a/rflib/openflow/rfofmsg.cc
+++ b/rflib/openflow/rfofmsg.cc
@@ -154,10 +154,14 @@ MSG create_config_msg(DATAPATH_CONFIG_OPERATION operation) {
 	} else if (operation == DC_ICMP) {
 		ofm_match_dl(ofm, OFPFW_DL_TYPE, 0x0800, 0, 0);
 		ofm_match_nw(ofm, OFPFW_NW_PROTO, 0x01, 0, 0, 0);
-	} else if (operation == DC_BGP) {
+	} else if (operation == DC_BGP_INBOUND) {
 		ofm_match_dl(ofm, OFPFW_DL_TYPE, 0x0800, 0, 0);
 		ofm_match_nw(ofm, OFPFW_NW_PROTO, 0x06, 0, 0, 0);
 		ofm_match_tp(ofm, OFPFW_TP_DST, 0, 0x00B3);
+	} else if (operation == DC_BGP_OUTBOUND) {
+		ofm_match_dl(ofm, OFPFW_DL_TYPE, 0x0800, 0, 0);
+		ofm_match_nw(ofm, OFPFW_NW_PROTO, 0x06, 0, 0, 0);
+		ofm_match_tp(ofm, OFPFW_TP_SRC, 0, 0x00B3);
 	} else if (operation == DC_VM_INFO) {
 		ofm_match_dl(ofm, OFPFW_DL_TYPE, RF_ETH_PROTO, 0, 0);
 	} else if (operation == DC_DROP_ALL) {

--- a/rflib/openflow/rfofmsg.py
+++ b/rflib/openflow/rfofmsg.py
@@ -50,10 +50,14 @@ def create_config_msg(operation):
     elif operation == DC_ICMP:
         ofm_match_dl(ofm, OFPFW_DL_TYPE, 0x0800)
         ofm_match_nw(ofm, OFPFW_NW_PROTO, 0x01, 0, 0, 0)
-    elif operation == DC_BGP:
+    elif operation == DC_BGP_INBOUND:
         ofm_match_dl(ofm, OFPFW_DL_TYPE, 0x0800)
         ofm_match_nw(ofm, OFPFW_NW_PROTO, 0x06, 0, 0, 0)
         ofm_match_tp(ofm, OFPFW_TP_DST, 0, 0x00B3)
+    elif operation == DC_BGP_OUTBOUND:
+        ofm_match_dl(ofm, OFPFW_DL_TYPE, 0x0800)
+        ofm_match_nw(ofm, OFPFW_NW_PROTO, 0x06, 0, 0, 0)
+        ofm_match_tp(ofm, OFPFW_TP_SRC, 0, 0x00B3)
     elif operation == DC_VM_INFO:
         ofm_match_dl(ofm, OFPFW_DL_TYPE, RF_ETH_PROTO)
     elif operation == DC_DROP_ALL:

--- a/rfserver/rfserver.py
+++ b/rfserver/rfserver.py
@@ -180,7 +180,8 @@ class RFServer(RFProtocolFactory, IPC.IPCMessageProcessor):
             self.send_datapath_config_message(dp_id, DC_CLEAR_FLOW_TABLE);
             # TODO: enforce order: clear should always be executed first
             self.send_datapath_config_message(dp_id, DC_OSPF);
-            self.send_datapath_config_message(dp_id, DC_BGP);
+            self.send_datapath_config_message(dp_id, DC_BGP_INBOUND);
+            self.send_datapath_config_message(dp_id, DC_BGP_OUTBOUND);
             self.send_datapath_config_message(dp_id, DC_RIPV2);
             self.send_datapath_config_message(dp_id, DC_ARP);
             self.send_datapath_config_message(dp_id, DC_ICMP);


### PR DESCRIPTION
Per correspondence with @chesteve, I have written a couple of patches to further lock down RouteFlow.

---

_Add rule to match incoming responses to BGP connections initialised from an rfvm_
- Previously, if BGP connections were initiated from the outside, then they would be successfully passed on to the controller with a rule matching the destination port of BGP requests. _eg, packet from external router->rfvm, random source port, BGP destination port_
- However, connections initiated from inside (ie, rfvm) would cause replies to be sent with the standard BGP _source_ port. _eg, rfvm->external router, quagga-specified local port, BGP destination port. The response goes external->rfvm, BGP source port, quagga-specified destination port_
- Added an extra rule to deal with this situation, forwarding to the controller as appropriate.
