### PR TITLE
Support for getting route updates from Quagga via the FPM interface

### DIFF
--- a/rfclient/FPMServer.cc
+++ b/rfclient/FPMServer.cc
@@ -189,7 +189,12 @@ void FPMServer::process_fpm_msg(fpm_msg_hdr_t *hdr) {
     warn_msg("Unknown fpm message type %u", hdr->msg_type);
     return;
   }
-  FlowTable::updateRouteTable((nlmsghdr *) fpm_msg_data(hdr));
+
+  struct nlmsghdr *n = (nlmsghdr *) fpm_msg_data(hdr);
+
+  if (n->nlmsg_type == RTM_NEWROUTE || n->nlmsg_type == RTM_DELROUTE){
+    FlowTable::updateRouteTable(n);
+  }
 }
 
 /*

--- a/rfclient/FPMServer.cc
+++ b/rfclient/FPMServer.cc
@@ -1,0 +1,661 @@
+/*
+ * Copyright (C) 2012  Internet Systems Consortium, Inc. ("ISC")
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ *
+ * This file uses code from fpm_stub.c
+ */
+
+#include <iostream>
+#include <sys/socket.h>
+#include <memory.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <assert.h>
+
+
+#include "FPMServer.h"
+#include "FlowTable.h"
+
+typedef struct glob_t_
+{
+  int server_sock;
+  int sock;
+} glob_t;
+
+glob_t glob_space;
+glob_t *glob = &glob_space;
+
+int log_level = 1;
+
+#define log(level, format...)     \
+do {            \
+  if (level <= log_level) {     \
+    fprintf(stderr, format);      \
+    fprintf(stderr, "\n");      \
+  }           \
+} while (0);
+
+#define NUM_OF(x) (sizeof(x) / sizeof(x[0]))
+
+#define warn_msg(format...) log(0, format)
+#define err_msg(format...) log(-1, format)
+#define trace log
+
+/*
+ * get_print_buf
+ */
+static char *
+get_print_buf (size_t *buf_len)
+{
+  static char print_bufs[16][128];
+  static int counter;
+
+  counter++;
+  if (counter >= 16) {
+    counter = 0;
+  }
+
+  *buf_len = 128;
+  return &print_bufs[counter][0];
+}
+
+/*
+ * create_listen_sock
+ */
+int
+create_listen_sock (int port, int *sock_p)
+{
+  int sock;
+  struct sockaddr_in addr;
+  int reuse;
+
+  sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (sock < 0) {
+    err_msg(0, "Failed to create socket: %s", strerror(errno));
+    return 0;
+  }
+
+  reuse = 1;
+  if (setsockopt (sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
+    {
+      warn_msg("Failed to set reuse addr option: %s", strerror(errno));
+    }
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(port);
+
+  if (bind(sock, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+    err_msg("Failed to bind to port %d: %s", port, strerror(errno));
+    close(sock);
+    return 0;
+  }
+
+  if (listen(sock, 5)) {
+    err_msg("Failed to listen on socket: %s", strerror(errno));
+    close(sock);
+    return 0;
+  }
+
+  *sock_p = sock;
+  return 1;
+}
+
+/*
+ * accept_conn
+ */
+int
+accept_conn (int listen_sock)
+{
+  int sock;
+  struct sockaddr_in client_addr;
+  unsigned int client_len;
+
+  while (1) {
+    trace(1, "Waiting for client connection...");
+    client_len = sizeof(client_addr);
+    sock = accept(listen_sock, (struct sockaddr *) &client_addr,
+    &client_len);
+
+    if (sock >= 0) {
+      trace(1, "Accepted client %s", inet_ntoa(client_addr.sin_addr));
+      return sock;
+    }
+
+    err_msg("Failed to accept socket: %s",  strerror(errno));
+  }
+}
+
+/*
+ * read_fpm_msg
+ */
+fpm_msg_hdr_t *
+read_fpm_msg (char *buf, size_t buf_len)
+{
+  char *cur, *end;
+  int need_len, bytes_read, have_len;
+  fpm_msg_hdr_t *hdr;
+  int reading_full_msg;
+
+  end = buf + buf_len;
+  cur = buf;
+  hdr = (fpm_msg_hdr_t *) buf;
+
+  while (1) {
+    reading_full_msg = 0;
+
+    have_len = cur - buf;
+
+    if (have_len < FPM_MSG_HDR_LEN) {
+      need_len = FPM_MSG_HDR_LEN - have_len;
+    } else {
+      need_len = fpm_msg_len(hdr) - have_len;
+      assert(need_len >= 0 && need_len < (end - cur));
+
+      if (!need_len)
+  return hdr;
+
+      reading_full_msg = 1;
+    }
+
+    trace(3, "Looking to read %d bytes", need_len);
+    bytes_read = read(glob->sock, cur, need_len);
+
+    if (bytes_read <= 0) {
+      err_msg("Error reading from socket: %s", strerror(errno));
+      return NULL;
+    }
+
+    trace(3, "Read %d bytes", bytes_read);
+    cur += bytes_read;
+
+    if (bytes_read < need_len) {
+      continue;
+    }
+
+    assert(bytes_read == need_len);
+
+    if (reading_full_msg)
+      return hdr;
+
+    if (!fpm_msg_ok(hdr, buf_len))
+      {
+  assert(0);
+  err_msg("Malformed fpm message");
+  return NULL;
+      }
+  }
+
+}
+
+/*
+ * netlink_msg_type_to_s
+ */
+const char *
+netlink_msg_type_to_s (uint16_t type)
+{
+  switch (type) {
+
+  case RTM_NEWROUTE:
+    return "New route";
+
+  case RTM_DELROUTE:
+    return "Del route";
+
+  default:
+    return "Unknown";
+  }
+}
+
+/*
+ * netlink_prot_to_s
+ */
+const char *
+netlink_prot_to_s (unsigned char prot)
+{
+  switch (prot) {
+
+  case RTPROT_KERNEL:
+    return "Kernel";
+
+  case RTPROT_BOOT:
+    return "Boot";
+
+  case RTPROT_STATIC:
+    return "Static";
+
+  case RTPROT_ZEBRA:
+    return "Zebra";
+
+  case RTPROT_DHCP:
+    return "Dhcp";
+
+  default:
+    return "Unknown";
+  }
+}
+
+#define MAX_NHS 16
+
+typedef struct netlink_nh_t {
+  struct rtattr *gateway;
+  int if_index;
+} netlink_nh_t;
+
+typedef struct netlink_msg_ctx_t_ {
+  struct nlmsghdr *hdr;
+
+  /*
+   * Stuff pertaining to route messages.
+   */
+  struct rtmsg *rtmsg;
+  struct rtattr *rtattrs[RTA_MAX + 1];
+
+  /*
+   * Nexthops.
+   */
+  struct netlink_nh_t nhs[MAX_NHS];
+  int num_nhs;
+
+  struct rtattr *dest;
+  struct rtattr *src;
+  int *metric;
+
+  const char *err_msg;
+} netlink_msg_ctx_t;
+
+/*
+ * netlink_msg_ctx_init
+ */
+static inline void
+netlink_msg_ctx_init (netlink_msg_ctx_t *ctx)
+{
+  memset(ctx, 0, sizeof(*ctx));
+}
+
+/*
+ * netlink_msg_ctx_set_err
+ */
+static inline void
+netlink_msg_ctx_set_err (netlink_msg_ctx_t *ctx, const char *err_msg)
+{
+  if (ctx->err_msg) {
+    return;
+  }
+  ctx->err_msg = err_msg;
+}
+
+/*
+ * netlink_msg_ctx_cleanup
+ */
+static inline void
+netlink_msg_ctx_cleanup (netlink_msg_ctx_t *ctx)
+{
+  return;
+}
+
+/*
+ * parse_rtattrs_
+ */
+int
+parse_rtattrs_ (struct rtattr *rta, size_t len, struct rtattr**rtas,
+    int num_rtas, const char **err_msg)
+{
+  memset(rtas, 0, num_rtas * sizeof(rtas[0]));
+
+  for (; len > 0; rta = RTA_NEXT(rta, len)) {
+    if (!RTA_OK(rta, len)) {
+      *err_msg = "Malformed rta";
+      return 0;
+    }
+
+    if (rta->rta_type >= num_rtas) {
+      //warn("Unknown rtattr type %d", rta->rta_type);
+      continue;
+    }
+
+    rtas[rta->rta_type] = rta;
+  }
+}
+
+/*
+ * parse_rtattrs
+ */
+int
+parse_rtattrs (netlink_msg_ctx_t *ctx, struct rtattr *rta, size_t len)
+{
+  const char *err_msg;
+
+  err_msg = NULL;
+
+  if (!parse_rtattrs_(rta, len, ctx->rtattrs, NUM_OF(ctx->rtattrs),
+          &err_msg)) {
+    netlink_msg_ctx_set_err(ctx, err_msg);
+    return 0;
+  }
+
+  return 1;
+}
+
+/*
+ * netlink_msg_ctx_add_nh
+ */
+static int
+netlink_msg_ctx_add_nh (netlink_msg_ctx_t *ctx, int if_index,
+      struct rtattr *gateway)
+{
+  netlink_nh_t *nh;
+
+  if (ctx->num_nhs + 1 >= NUM_OF(ctx->nhs)) {
+    //warn("Too many next hops");
+    return 0;
+  }
+  nh = &ctx->nhs[ctx->num_nhs];
+  ctx->num_nhs++;
+
+  nh->gateway = gateway;
+  nh->if_index = if_index;
+  return 1;
+}
+
+/*
+ * parse_multipath_attr
+ */
+int
+parse_multipath_attr (netlink_msg_ctx_t *ctx, struct rtattr *mpath_rtattr)
+{
+  size_t len, attr_len;
+  struct rtnexthop *rtnh;
+  struct rtattr *rtattrs[RTA_MAX + 1];
+  struct rtattr *rtattr, *gateway;
+  int if_index;
+  const char *err_msg;
+
+  rtnh = (rtnexthop*) RTA_DATA(mpath_rtattr);
+  len = RTA_PAYLOAD(mpath_rtattr);
+
+  for (; len > 0;
+       len -= NLMSG_ALIGN(rtnh->rtnh_len), rtnh = RTNH_NEXT(rtnh)) {
+
+    if (!RTNH_OK(rtnh, len)) {
+      netlink_msg_ctx_set_err(ctx, "Malformed nh");
+      return 0;
+    }
+
+    if (rtnh->rtnh_len <= sizeof(*rtnh)) {
+      netlink_msg_ctx_set_err(ctx, "NH len too small");
+      return 0;
+    }
+
+    /*
+     * Parse attributes included in the nexthop.
+     */
+    err_msg = NULL;
+    if (!parse_rtattrs_(RTNH_DATA(rtnh), rtnh->rtnh_len - sizeof(*rtnh),
+      rtattrs, NUM_OF(rtattrs), &err_msg)) {
+      netlink_msg_ctx_set_err(ctx, err_msg);
+      return 0;
+    }
+
+    gateway = rtattrs[RTA_GATEWAY];
+    netlink_msg_ctx_add_nh(ctx, rtnh->rtnh_ifindex, gateway);
+  }
+
+  return 1;
+}
+
+/*
+ * parse_route_msg
+ */
+int
+parse_route_msg (netlink_msg_ctx_t *ctx)
+{
+  int len;
+  struct rtattr **rtattrs, *rtattr, *gateway, *oif;
+  int if_index;
+
+  ctx->rtmsg = (rtmsg*) NLMSG_DATA(ctx->hdr);
+
+  len = ctx->hdr->nlmsg_len - NLMSG_LENGTH(sizeof(struct rtmsg));
+  if (len < 0) {
+    netlink_msg_ctx_set_err(ctx, "Bad message length");
+    return 0;
+  }
+
+  if (!parse_rtattrs(ctx, RTM_RTA(ctx->rtmsg), len)) {
+    return 0;
+  }
+
+  rtattrs = ctx->rtattrs;
+
+  ctx->dest = rtattrs[RTA_DST];
+  ctx->src = rtattrs[RTA_PREFSRC];
+
+  rtattr = rtattrs[RTA_PRIORITY];
+  if (rtattr) {
+    ctx->metric = (int *) RTA_DATA(rtattr);
+  }
+
+  gateway = rtattrs[RTA_GATEWAY];
+  oif = rtattrs[RTA_OIF];
+  if (gateway || oif) {
+    if_index = 0;
+    if (oif) {
+      if_index = *((int *) RTA_DATA(oif));
+    }
+    netlink_msg_ctx_add_nh(ctx, if_index, gateway);
+  }
+
+  rtattr = rtattrs[RTA_MULTIPATH];
+  if (rtattr) {
+    parse_multipath_attr(ctx, rtattr);
+  }
+
+  return 1;
+}
+
+/*
+ * addr_to_s
+ */
+const char *
+addr_to_s (unsigned char family, void *addr)
+{
+  size_t buf_len;
+  char *buf;
+
+  buf = get_print_buf(&buf_len);
+
+  return inet_ntop(family, addr, buf, buf_len);
+}
+
+/*
+ * netlink_msg_ctx_print
+ */
+int
+netlink_msg_ctx_snprint (netlink_msg_ctx_t *ctx, char *buf, size_t buf_len)
+{
+  struct nlmsghdr *hdr;
+  struct rtmsg *rtmsg;
+  netlink_nh_t *nh;
+  char *cur, *end;
+  int i;
+
+  hdr = ctx->hdr;
+  rtmsg = ctx->rtmsg;
+
+  cur = buf;
+  end = buf + buf_len;
+
+  cur += snprintf(cur, end - cur, "%s %s/%d, Prot: %s",
+      netlink_msg_type_to_s(hdr->nlmsg_type),
+      addr_to_s(rtmsg->rtm_family, RTA_DATA(ctx->dest)),
+      rtmsg->rtm_dst_len,
+      netlink_prot_to_s(rtmsg->rtm_protocol));
+
+  if (ctx->metric) {
+    cur += snprintf(cur, end - cur, ", Metric: %d", *ctx->metric);
+  }
+
+  for (i = 0; i < ctx->num_nhs; i++) {
+    cur += snprintf(cur, end - cur, "\n ");
+    nh = &ctx->nhs[i];
+
+    if (nh->gateway) {
+      cur += snprintf(cur, end - cur, " %s",
+          addr_to_s(rtmsg->rtm_family, RTA_DATA(nh->gateway)));
+    }
+
+    if (nh->if_index) {
+      cur += snprintf(cur, end - cur, " via interface %d", nh->if_index);
+    }
+  }
+
+  return cur - buf;
+}
+
+/*
+ * print_netlink_msg_ctx
+ */
+void
+print_netlink_msg_ctx (netlink_msg_ctx_t *ctx)
+{
+  char buf[1024];
+
+  netlink_msg_ctx_snprint(ctx, buf, sizeof(buf));
+  printf("%s\n", buf);
+}
+
+/*
+ * parse_netlink_msg
+ */
+void
+parse_netlink_msg (char *buf, size_t buf_len)
+{
+  netlink_msg_ctx_t ctx_space, *ctx;
+  struct nlmsghdr *hdr;
+  int status;
+  int len;
+
+  std::cout << "parse_netlink_msg\n";
+
+  ctx = &ctx_space;
+
+  hdr = (struct nlmsghdr *) buf;
+  len = buf_len;
+  for (; NLMSG_OK (hdr, len); hdr = NLMSG_NEXT(hdr, len)) {
+
+    netlink_msg_ctx_init(ctx);
+    ctx->hdr = (struct nlmsghdr *) buf;
+
+    switch (hdr->nlmsg_type) {
+
+    case RTM_DELROUTE:
+    case RTM_NEWROUTE:
+
+      parse_route_msg(ctx);
+      if (ctx->err_msg) {
+        err_msg("Error parsing route message: %s", ctx->err_msg);
+      }
+
+      //print_netlink_msg_ctx(ctx);
+      break;
+
+    default:
+      trace(1, "Ignoring unknown netlink message - Type: %d", hdr->nlmsg_type);
+    }
+
+    netlink_msg_ctx_cleanup(ctx);
+  }
+}
+
+/*
+ * process_fpm_msg
+ */
+void
+process_fpm_msg (fpm_msg_hdr_t *hdr)
+{
+  trace(1, "FPM message - Type: %d, Length %d", hdr->msg_type,
+  ntohs(hdr->msg_len));
+
+  //std::cout << "FPM hex dump:\n";
+  //DumpHex::hexdump(hdr,ntohs(hdr->msg_len));
+  //std::cout << "FPM minus header hex dump:\n";
+  //DumpHex::hexdump((char*)fpm_msg_data (hdr), fpm_msg_data_len (hdr));
+
+  if (hdr->msg_type != FPM_MSG_TYPE_NETLINK) {
+    //warn("Unknown fpm message type %u", hdr->msg_type);
+    return;
+  }
+
+  std::cout << "Sending fpm_msg_data to updateRouteTable2\n";
+
+  FlowTable::updateRouteTable((nlmsghdr *)fpm_msg_data(hdr));
+
+  std::cout << "Done sending fpm_msg_data to updateRouteTable2\n";
+
+  parse_netlink_msg ((char*)fpm_msg_data (hdr), fpm_msg_data_len (hdr));
+}
+
+/*
+ * fpm_serve
+ */
+void
+fpm_serve ()
+{
+  char buf[FPM_MAX_MSG_LEN];
+  fpm_msg_hdr_t *hdr;
+
+  while (1) {
+
+    hdr = read_fpm_msg(buf, sizeof(buf));
+    if (!hdr) {
+      return;
+    }
+
+    process_fpm_msg(hdr);
+  }
+}
+
+
+
+
+void FPMServer::start(){
+
+  int sock;
+
+  memset(glob, 0, sizeof(*glob));
+
+  if (!create_listen_sock(FPM_DEFAULT_PORT, &glob->server_sock)) {
+    exit(1);
+  }
+
+  /*
+   * Server forever.
+   */
+  while (1) {
+    glob->sock = accept_conn(glob->server_sock);
+    fpm_serve();
+    trace(1, "Done serving client");
+  }
+}

--- a/rfclient/FPMServer.h
+++ b/rfclient/FPMServer.h
@@ -1,0 +1,17 @@
+
+#ifndef RFCLIENT_FPMSERVER_H_
+#define RFCLIENT_FPMSERVER_H_
+
+#include <assert.h>
+#include "../quagga-fpm/fpm/fpm.h"
+
+class FPMServer {
+ public:
+  static void start();
+
+ private:
+};
+
+
+
+#endif  // RFCLIENT_FPMSERVER_H_

--- a/rfclient/FPMServer.h
+++ b/rfclient/FPMServer.h
@@ -1,17 +1,24 @@
 
 #ifndef RFCLIENT_FPMSERVER_H_
 #define RFCLIENT_FPMSERVER_H_
-
+#ifdef FPM_ENABLED
 #include <assert.h>
-#include "../quagga-fpm/fpm/fpm.h"
+
+#include <fpm.h>
 
 class FPMServer {
  public:
   static void start();
 
  private:
+  static int create_listen_sock (int port, int *sock_p);
+  static int accept_conn (int listen_sock);
+  static void fpm_serve ();
+  static fpm_msg_hdr_t * read_fpm_msg (char *buf, size_t buf_len);
+  static void process_fpm_msg (fpm_msg_hdr_t *hdr);
+
 };
 
 
-
+#endif
 #endif  // RFCLIENT_FPMSERVER_H_

--- a/rfclient/FlowTable.cc
+++ b/rfclient/FlowTable.cc
@@ -5,10 +5,10 @@
 #include <netdb.h>
 #include <sys/socket.h>
 
-
 #include "ipc/RFProtocol.h"
 #include "converter.h"
 #include "defs.h"
+
 
 #include "FlowTable.h"
 #ifdef FPM_ENABLED

--- a/rfclient/FlowTable.h
+++ b/rfclient/FlowTable.h
@@ -11,7 +11,6 @@
 #include "types/IPAddress.h"
 #include "types/MACAddress.h"
 
-
 using namespace std;
 
 class Interface {

--- a/rfclient/FlowTable.h
+++ b/rfclient/FlowTable.h
@@ -11,6 +11,7 @@
 #include "types/IPAddress.h"
 #include "types/MACAddress.h"
 
+
 using namespace std;
 
 class Interface {

--- a/rfclient/FlowTable.h
+++ b/rfclient/FlowTable.h
@@ -83,7 +83,6 @@ class HostEntry {
 // It is a little bit challenging to devise a decent API due to netlink
 class FlowTable {
     public:
-        static void RTPollingCb();
         static void HTPollingCb();
         static void fakeReq(const char *hostAddr, const char *intf);
         static void clear();
@@ -92,10 +91,14 @@ class FlowTable {
         static void print_test();
 
         static int updateHostTable(const struct sockaddr_nl *who, struct nlmsghdr *n, void *arg);
-        static int updateRouteTable(const struct sockaddr_nl *who, struct nlmsghdr *n, void *arg);
+        #ifndef FPM_ENABLED
+          static void RTPollingCb();
+          static int updateRouteTable(const struct sockaddr_nl *who, struct nlmsghdr *n, void *arg);
+        #endif /* FPM_ENABLED */
         static int updateRouteTable(struct nlmsghdr *n);
+
     private:
-        static struct rtnl_handle rth;
+
         static struct rtnl_handle rthNeigh;
         static int family;
         static unsigned groups;
@@ -107,10 +110,15 @@ class FlowTable {
         static vector<uint32_t>* down_ports;
         static IPCMessageService* ipc;
         static uint64_t vm_id;
-        
+        #ifdef FPM_ENABLED
+          static boost::thread FPMClient;
+        #else
+          static struct rtnl_handle rth;
+          static boost::thread RTPolling;
+        #endif /* FPM_ENABLED */
         static boost::thread HTPolling;
-        static boost::thread RTPolling;
-        static boost::thread FPMClient;
+
+        
 
         static list<RouteEntry> routeTable;
         static list<HostEntry> hostTable;

--- a/rfclient/FlowTable.h
+++ b/rfclient/FlowTable.h
@@ -93,7 +93,7 @@ class FlowTable {
 
         static int updateHostTable(const struct sockaddr_nl *who, struct nlmsghdr *n, void *arg);
         static int updateRouteTable(const struct sockaddr_nl *who, struct nlmsghdr *n, void *arg);
-        
+        static int updateRouteTable(struct nlmsghdr *n);
     private:
         static struct rtnl_handle rth;
         static struct rtnl_handle rthNeigh;
@@ -110,6 +110,7 @@ class FlowTable {
         
         static boost::thread HTPolling;
         static boost::thread RTPolling;
+        static boost::thread FPMClient;
 
         static list<RouteEntry> routeTable;
         static list<HostEntry> hostTable;

--- a/rfclient/Makefile
+++ b/rfclient/Makefile
@@ -1,3 +1,6 @@
 MAKEAPPS := rfclient
 
+#The below line enables the FPM connection to Quagga, the include directory 
+#needs to point to fpm.h in quagga
+CFLAGS += -DFPM_ENABLED -I../../quagga-fpm/fpm/ 
 include ../Make.rules

--- a/rfclient/Makefile
+++ b/rfclient/Makefile
@@ -2,5 +2,5 @@ MAKEAPPS := rfclient
 
 #The below line enables the FPM connection to Quagga, the include directory 
 #needs to point to fpm.h in quagga
-CFLAGS += -DFPM_ENABLED -I../../quagga-fpm/fpm/ 
+#CFLAGS += -DFPM_ENABLED -I../../quagga-fpm/fpm/ 
 include ../Make.rules

--- a/rfclient/RFClient.cc
+++ b/rfclient/RFClient.cc
@@ -304,6 +304,7 @@ class RFClient : private RFProtocolFactory, private IPCMessageProcessor {
 };
 
 int main(int argc, char* argv[]) {
+  setvbuf(stdout,NULL,_IOLBF,0);
     char c;
     stringstream ss;
     string id;

--- a/rfclient/RFClient.cc
+++ b/rfclient/RFClient.cc
@@ -22,8 +22,6 @@
 
 #define BUFFER_SIZE 23 /* Mapping packet size. */
 
-
-
 using namespace std;
 
 /* Get the MAC address of the interface. */
@@ -76,7 +74,6 @@ uint64_t get_interface_id(const char *ifname) {
 class RFClient : private RFProtocolFactory, private IPCMessageProcessor {
     public:
         RFClient(uint64_t id, const string &address) {
-
             this->id = id;
             syslog(LOG_INFO, "Starting RFClient (vm_id=%s)", to_string<uint64_t>(this->id).c_str());
             ipc = (IPCMessageService*) new MongoIPCMessageService(address, MONGO_DB_NAME, to_string<uint64_t>(this->id));
@@ -99,7 +96,6 @@ class RFClient : private RFProtocolFactory, private IPCMessageProcessor {
         }
 
     private:
-
         FlowTable* flowTable;
         IPCMessageService* ipc;
         uint64_t id;
@@ -308,13 +304,14 @@ class RFClient : private RFProtocolFactory, private IPCMessageProcessor {
 };
 
 int main(int argc, char* argv[]) {
-  setvbuf(stdout,NULL,_IOLBF,0);
+    //Disable buffering of standard out, without this when the output was sent to a file
+    //(i.e for logging) it didn't always write
+    setvbuf(stdout,NULL,_IOLBF,0); 
     char c;
     stringstream ss;
     string id;
     string address = MONGO_ADDRESS;
-
-    while ((c = getopt (argc, argv, "n:i:a:l")) != -1)
+    while ((c = getopt (argc, argv, "n:i:a:")) != -1)
         switch (c) {
             case 'n':
                 fprintf (stderr, "Custom naming not supported yet.");
@@ -340,7 +337,6 @@ int main(int argc, char* argv[]) {
             case '?':
                 if (optopt == 'n' || optopt == 'i' || optopt == 'a')
                     fprintf(stderr, "Option -%c requires an argument.\n", optopt);
-
                 else if (isprint(optopt))
                     fprintf(stderr, "Unknown option `-%c'.\n", optopt);
                 else

--- a/rfclient/RFClient.cc
+++ b/rfclient/RFClient.cc
@@ -22,6 +22,8 @@
 
 #define BUFFER_SIZE 23 /* Mapping packet size. */
 
+
+
 using namespace std;
 
 /* Get the MAC address of the interface. */
@@ -74,6 +76,7 @@ uint64_t get_interface_id(const char *ifname) {
 class RFClient : private RFProtocolFactory, private IPCMessageProcessor {
     public:
         RFClient(uint64_t id, const string &address) {
+
             this->id = id;
             syslog(LOG_INFO, "Starting RFClient (vm_id=%s)", to_string<uint64_t>(this->id).c_str());
             ipc = (IPCMessageService*) new MongoIPCMessageService(address, MONGO_DB_NAME, to_string<uint64_t>(this->id));
@@ -96,6 +99,7 @@ class RFClient : private RFProtocolFactory, private IPCMessageProcessor {
         }
 
     private:
+
         FlowTable* flowTable;
         IPCMessageService* ipc;
         uint64_t id;
@@ -309,7 +313,8 @@ int main(int argc, char* argv[]) {
     stringstream ss;
     string id;
     string address = MONGO_ADDRESS;
-    while ((c = getopt (argc, argv, "n:i:a:")) != -1)
+
+    while ((c = getopt (argc, argv, "n:i:a:l")) != -1)
         switch (c) {
             case 'n':
                 fprintf (stderr, "Custom naming not supported yet.");
@@ -335,6 +340,7 @@ int main(int argc, char* argv[]) {
             case '?':
                 if (optopt == 'n' || optopt == 'i' || optopt == 'a')
                     fprintf(stderr, "Option -%c requires an argument.\n", optopt);
+
                 else if (isprint(optopt))
                     fprintf(stderr, "Unknown option `-%c'.\n", optopt);
                 else


### PR DESCRIPTION
Routing updates can now directly come from Quagga via the new FPM (Forward Plane Manager) interface (this has not yet been merged with the main branch of Quagga, but it is in the works).

Most of the work is done by FPMServer. This is based on fpm_stub, written by Avneesh Sachdev, which is a test program for the Quagga FPM interface.

By default this change should do nothing. To enable the new changes the make file needs modifying so it passes in the flag FPM_ENABLED and also provides the include directory for fpm.h which is part of the version of Quagga with FPM support. This can be done by uncommenting the line
# CFLAGS += -DFPM_ENABLED -I../../quagga-fpm/fpm/

This assumes that the version of Quagga with FPM support is in the same directory as RouteFlow.

The fpm-stub program that this is based off can be found here https://github.com/opensourcerouting/fpm-stub
