### PR TITLE
rflib/rfofmsg: Increase limit on route packet size

### DIFF
--- a/rflib/defs.h
+++ b/rflib/defs.h
@@ -18,6 +18,12 @@
 
 #define RF_ETH_PROTO 0x0A0A /* RF ethernet protocol */
 
+#define VLAN_HEADER_LEN 4
+#define ETH_HEADER_LEN 14
+#define ETH_PAYLOAD_MAX 1500
+#define ETH_TOTAL_MAX (ETH_HEADER_LEN + ETH_PAYLOAD_MAX)
+#define ETH_VLAN_TOTAL_MAX (ETH_HEADER_LEN + VLAN_HEADER_LEN + ETH_PAYLOAD_MAX)
+
 // We must match_l2 in order for packets to go up
 #define MATCH_L2 true
 

--- a/rflib/openflow/rfofmsg.cc
+++ b/rflib/openflow/rfofmsg.cc
@@ -173,7 +173,7 @@ MSG create_config_msg(DATAPATH_CONFIG_OPERATION operation) {
 		ofm->priority = htons(0);
 	} else {
 		ofm_set_command(ofm, OFPFC_ADD, UINT32_MAX, OFP_FLOW_PERMANENT, OFP_FLOW_PERMANENT, OFPP_NONE);
-		ofm_set_action(ofm->actions, OFPAT_OUTPUT, sizeof(ofp_action_output), OFPP_CONTROLLER, ETH_DATA_LEN, 0);
+		ofm_set_action(ofm->actions, OFPAT_OUTPUT, sizeof(ofp_action_output), OFPP_CONTROLLER, ETH_VLAN_TOTAL_MAX, 0);
 	}
     
     return msg_new((uint8_t*) &ofm->header, size);


### PR DESCRIPTION
We previously allowed common routing protocol traffic to be forwarded to
the controller with a maximum size of 1500 bytes (ETH_MAX_LEN),
including headers. However, there are cases where large updates may
exceed this value when wrapped in ethernet and vlan headers. Currently,
such updates are dropped rather than forwarded.

This patch copies the ETH size defines from nox/src/include/packets.h to
defs.h, and increases the default maximum length of routing protocol
packets to 1518 (ETH_VLAN_TOTAL_MAX), which accounts for ethernet and
VLAN headers.

Signed-off-by: Joe Stringer joestringernz@gmail.com
