### PR TITLE
Simplify rfofmsg.cc functions

### DIFF
--- a/rflib/openflow/rfofmsg.cc
+++ b/rflib/openflow/rfofmsg.cc
@@ -224,6 +224,17 @@ void ofm_set_command(ofp_flow_mod* ofm, enum ofp_flow_mod_command cmd,
 }
 
 /**
+ * Set FlowMod attributes
+ *
+ * ofm: FlowMod to modify
+ * cmd: Command - OFPFC_*
+ */
+void ofm_set_command(ofp_flow_mod* ofm, enum ofp_flow_mod_command cmd) {
+    ofm_set_command(ofm, cmd, OFP_BUFFER_NONE, OFP_FLOW_PERMANENT,
+                    OFP_FLOW_PERMANENT, OFPP_NONE);
+}
+
+/**
  * Convert the given CIDR mask to an OpenFlow 1.0 match bitmask
  *
  * mask: CIDR mask, eg 24
@@ -272,12 +283,10 @@ MSG create_config_msg(DATAPATH_CONFIG_OPERATION operation) {
     ofm_init(ofm, size);
 
     if (operation == DC_CLEAR_FLOW_TABLE) {
-        ofm_set_command(ofm, OFPFC_DELETE, 0, OFP_FLOW_PERMANENT,
-                        OFP_FLOW_PERMANENT, OFPP_NONE);
+        ofm_set_command(ofm, OFPFC_DELETE);
         ofm->priority = htons(0);
     } else if (operation == DC_DROP_ALL) {
-        ofm_set_command(ofm, OFPFC_ADD, 0, OFP_FLOW_PERMANENT,
-                        OFP_FLOW_PERMANENT, OFPP_NONE);
+        ofm_set_command(ofm, OFPFC_ADD);
         /* No action implies discard. */
         ofm->priority = htons(1);
     } else {
@@ -325,8 +334,7 @@ MSG create_config_msg(DATAPATH_CONFIG_OPERATION operation) {
                 break;
         }
 
-        ofm_set_command(ofm, OFPFC_ADD, UINT32_MAX, OFP_FLOW_PERMANENT,
-                        OFP_FLOW_PERMANENT, OFPP_NONE);
+        ofm_set_command(ofm, OFPFC_ADD);
         ofm_set_action(ofm->actions, OFPAT_OUTPUT, OFPP_CONTROLLER, 0);
     }
 
@@ -360,8 +368,7 @@ MSG create_flow_install_msg(uint32_t ip, uint32_t mask, uint8_t srcMac[],
     }
     ofm_match_nw(ofm, ofp_get_mask(mask, OFPFW_NW_DST_SHIFT), 0, 0, 0, ip);
 
-    ofm_set_command(ofm, OFPFC_ADD, UINT32_MAX, OFP_FLOW_PERMANENT,
-                    OFP_FLOW_PERMANENT, OFPP_NONE);
+    ofm_set_command(ofm, OFPFC_ADD);
 
     if (mask == 32) {
         ofm->idle_timeout = htons(300);
@@ -410,8 +417,7 @@ MSG create_flow_remove_msg(uint32_t ip, uint32_t mask, uint8_t srcMac[]) {
     ofm_match_nw(ofm, ofp_get_mask(mask, OFPFW_NW_DST_SHIFT), 0, 0, 0, ip);
 
     ofm->priority = htons((OFP_DEFAULT_PRIORITY + mask));
-    ofm_set_command(ofm, OFPFC_DELETE_STRICT, UINT32_MAX, 0,
-                    OFP_FLOW_PERMANENT, OFPP_NONE);
+    ofm_set_command(ofm, OFPFC_DELETE_STRICT);
 
     return msg_new((uint8_t*) &ofm->header, size);
 }
@@ -443,7 +449,7 @@ MSG create_temporary_flow_msg(uint32_t ip, uint32_t mask, uint8_t srcMac[]) {
     ofm_match_nw(ofm, ofp_get_mask(mask, OFPFW_NW_DST_SHIFT), 0, 0, 0, ip);
 
     ofm->priority = htons((OFP_DEFAULT_PRIORITY + mask));
-    ofm_set_command(ofm, OFPFC_ADD, UINT32_MAX, 60, OFP_FLOW_PERMANENT,
+    ofm_set_command(ofm, OFPFC_ADD, OFP_BUFFER_NONE, 60, OFP_FLOW_PERMANENT,
                     OFPP_NONE);
     ofm_set_action(ofm->actions, OFPAT_OUTPUT, 0, 0);
 

--- a/rflib/openflow/rfofmsg.h
+++ b/rflib/openflow/rfofmsg.h
@@ -29,7 +29,7 @@ void ofm_match_dl(ofp_flow_mod* ofm, uint32_t match, uint16_t type, const uint8_
 void ofm_match_vlan(ofp_flow_mod* ofm, uint32_t match, uint16_t id, uint8_t priority);
 void ofm_match_nw(ofp_flow_mod* ofm, uint32_t match, uint8_t proto, uint8_t tos, uint32_t src, uint32_t dst);
 void ofm_match_tp(ofp_flow_mod* ofm, uint32_t match, uint16_t src, uint16_t dst);
-void ofm_set_action(ofp_action_header* hdr, uint16_t type, uint16_t len, uint16_t port, uint16_t max_len, const uint8_t addr[]);
+void ofm_set_action(ofp_action_header* hdr, uint16_t type, uint16_t port, const uint8_t addr[]);
 void ofm_set_command(ofp_flow_mod* ofm, uint16_t cmd, uint32_t id, uint16_t idle_to, uint16_t hard_to, uint16_t port);
 
 MSG create_config_msg(DATAPATH_CONFIG_OPERATION operation);

--- a/rflib/openflow/rfofmsg.h
+++ b/rflib/openflow/rfofmsg.h
@@ -23,6 +23,9 @@ size_t msg_size(MSG msg);
 void msg_save(MSG msg, const char* fname);
 void msg_delete(MSG msg);
 
+uint32_t ofp_get_mask(struct in_addr, int shift);
+uint32_t ofp_get_mask(uint8_t, int shift);
+
 void ofm_init(ofp_flow_mod* ofm, size_t size);
 void ofm_match_in(ofp_flow_mod* ofm, uint16_t in);
 void ofm_match_dl(ofp_flow_mod* ofm, uint32_t match, uint16_t type, const uint8_t src[], const uint8_t dst[]);

--- a/rflib/openflow/rfofmsg.h
+++ b/rflib/openflow/rfofmsg.h
@@ -10,7 +10,7 @@
 #include "openflow.h"
 #include "defs.h"
 
-#define UINT32_MAX      (4294967295U)
+#define OFP_BUFFER_NONE (0xffffffff)
 
 #define IPPROTO_OSPF    0x59
 #define IPADDR_RIPv2    (inet_addr("224.0.0.9"))
@@ -33,6 +33,8 @@ void ofm_match_vlan(ofp_flow_mod* ofm, uint32_t match, uint16_t id, uint8_t prio
 void ofm_match_nw(ofp_flow_mod* ofm, uint32_t match, uint8_t proto, uint8_t tos, uint32_t src, uint32_t dst);
 void ofm_match_tp(ofp_flow_mod* ofm, uint32_t match, uint16_t src, uint16_t dst);
 void ofm_set_action(ofp_action_header* hdr, uint16_t type, uint16_t port, const uint8_t addr[]);
+
+void ofm_set_command(ofp_flow_mod* ofm, enum ofp_flow_mod_command cmd);
 void ofm_set_command(ofp_flow_mod* ofm, uint16_t cmd, uint32_t id, uint16_t idle_to, uint16_t hard_to, uint16_t port);
 
 MSG create_config_msg(DATAPATH_CONFIG_OPERATION operation);


### PR DESCRIPTION
This patch series consolidates and simplifies a few of the functions in rfofmsg.cc.

Functionally, we see a change in the DC_DROP_ALL rule installation, which previously associated with buffer 0, but is now 0xffffffff (no associated buffer, we call this OFP_BUFFER_NONE).

There are also new functions to simplify OF1.0 IP mask creation based on CIDR or full IPv4 masks.
