### PR TITLE
build.sh script fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,8 @@ usage() {
 }
 
 verlte() {
-    [ "$1" != `echo -e "$1\n$2" | sort -V | head -n1` ]
+    local result=`echo "$1 < $2" | bc`
+    [ "$result" = "1" ]
 }
 
 verlt() {

--- a/dist/build_ovs.sh
+++ b/dist/build_ovs.sh
@@ -16,12 +16,12 @@ install_ovs() {
     $SUPER cp datapath/linux/*.ko /lib/modules/`uname -r`/kernel/net/ovs/ ||
         return 1
     $SUPER depmod -a || return 1
-    $SUPER modprobe openvswitch_mod || return 1
-    grep -q openvswitch_mod /etc/modules
+    $SUPER modprobe openvswitch || return 1
+    grep -q openvswitch /etc/modules
 
     status=$?
     if [ $status -eq 1 ]; then
-        $SUPER echo "openvswitch_mod" >>/etc/modules || return 1
+        $SUPER echo "openvswitch" >>/etc/modules || return 1
     elif [ $status -ne 0 ]; then
         print_status "Can't add openvswitch_mod to /etc/modules" $YELLOW
     fi


### PR DESCRIPTION
These changes improve the reliability of Ubuntu version detection (e.g., on 12.10 Quantal) and modifies the ovs module installation script to match the current upstream module name.
